### PR TITLE
Add raw string functions

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -13,8 +13,12 @@ type cacheConnector interface {
 type store interface {
 	// GetString gets a string value from the store
 	GetString(key string) (string, error)
+	// GetRawString gets a raw string value from the store
+	GetRawString(key string) (string, error)
 	// Put puts a value in the given store for a predetermined amount of time in seconds
 	Put(key string, value interface{}, seconds int) error
+	// PutRawString puts a raw string value in the given store for a predetermined amount of time in seconds
+	PutRawString(key, value string, seconds int) error
 	// Increment increments an integer counter by a given value
 	Increment(key string, value int64) (int64, error)
 	// Decrement decrements an integer counter by a given value

--- a/map_store.go
+++ b/map_store.go
@@ -23,6 +23,16 @@ func (ms *MapStore) GetString(key string) (string, error) {
 	return simpleDecode(fmt.Sprint(value))
 }
 
+// GetRawString gets a raw string value from the store
+func (ms *MapStore) GetRawString(key string) (string, error) {
+	value, valid := ms.client[ms.GetPrefix()+key]
+	if !valid {
+		return "", errors.New(mapNilErrorResponse)
+	}
+
+	return value.(string), nil
+}
+
 // GetFloat64 gets a float value from the store
 func (ms *MapStore) GetFloat64(key string) (float64, error) {
 	value, valid := ms.client[ms.GetPrefix()+key]
@@ -83,6 +93,13 @@ func (ms *MapStore) Put(key string, value interface{}, _ int) error {
 	}
 
 	ms.client[ms.GetPrefix()+key] = val
+
+	return nil
+}
+
+// PutRawString puts a string in the given store for a predetermined amount of time
+func (ms *MapStore) PutRawString(key, value string, _ int) error {
+	ms.client[ms.GetPrefix()+key] = value
 
 	return nil
 }

--- a/redis_store.go
+++ b/redis_store.go
@@ -34,6 +34,16 @@ func (rs *RedisStore) GetString(key string) (string, error) {
 	return simpleDecode(value)
 }
 
+// GetRawString gets a raw string value from the store
+func (rs *RedisStore) GetRawString(key string) (string, error) {
+	value, err := rs.get(key).Result()
+	if err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
 // Increment increments an integer counter by a given value
 func (rs *RedisStore) Increment(key string, value int64) (int64, error) {
 	return rs.client.IncrBy(rs.prefix+key, value).Result()
@@ -57,6 +67,13 @@ func (rs *RedisStore) Put(key string, value interface{}, seconds int) error {
 	}
 
 	return rs.client.Set(rs.GetPrefix()+key, val, duration).Err()
+}
+
+// PutRawString puts a raw string value in the given store for a predetermined amount of time in seconds
+func (rs *RedisStore) PutRawString(key, value string, seconds int) error {
+	duration := time.Duration(int64(seconds)) * time.Second
+
+	return rs.client.Set(rs.GetPrefix()+key, value, duration).Err()
 }
 
 // Forever puts a value in the given store until it is forgotten/evicted

--- a/tagged_cache.go
+++ b/tagged_cache.go
@@ -21,6 +21,11 @@ func (tc *taggedCache) Put(key string, value interface{}, seconds int) error {
 	return tc.store.Put(tagKey, value, seconds)
 }
 
+// PutRawString puts a raw string value in the given store for a predetermined amount of time in seconds
+func (tc *taggedCache) PutRawString(key, value string, seconds int) error {
+	return tc.Put(key, value, seconds)
+}
+
 // Increment increments an integer counter by a given value
 func (tc *taggedCache) Increment(key string, value int64) (int64, error) {
 	tagKey, err := tc.taggedItemKey(key)
@@ -154,6 +159,10 @@ func (tc *taggedCache) GetString(key string) (string, error) {
 	}
 
 	return tc.store.GetString(tagKey)
+}
+
+func (tc *taggedCache) GetRawString(key string) (string, error) {
+	return tc.GetString(key)
 }
 
 // TagFlush flushes the tags of the taggedCache


### PR DESCRIPTION
Adds `GetRawString` and `PutRawString` to all cache implementations store strings without having to encode/decode them. 